### PR TITLE
Add composer install to Selfupdate

### DIFF
--- a/src/WecampBot/SelfUpdate.php
+++ b/src/WecampBot/SelfUpdate.php
@@ -6,27 +6,35 @@ use \PhpSlackBot\Command\BaseCommand;
 
 class SelfUpdate extends BaseCommand
 {
+    private $updateCodebaseCommand = "/usr/bin/git pull 2>&1";
+    private $updateDependenciesCommand = "composer install --no-interaction --no-scripts";
+
     protected function configure() {
         $this->setName('!selfupdate');
     }
 
     protected function execute($message, $context) {
-        $result = shell_exec("/usr/bin/git pull 2>&1");
 
-        if ($result === "Already up-to-date.\n") {
-            $this->send($this->getCurrentChannel(), null, 'My codez are already up to date');
-            return;
-        }
+        $this->tellThem('Updating my codez');
+        $this->tellThem('```' . shell_exec($this->updateCodebaseCommand) . '```');
 
-        $this->send($this->getCurrentChannel(), null, "Updating my codez and restarting");
-        $this->send($this->getCurrentChannel(), null, '```' . $result . '```');
+        $this->tellThem('Updating my dependencies');
+        $this->tellThem('```' . shell_exec($this->updateDependenciesCommand) . '```');
+
+        $this->tellThem('Restarting in 5...');
 
         /**
          * Close the client and end the React loop
          * This will cause the program to end, and supervisorctl to restart it
          */
-        sleep(3);
+        sleep(5);
         $this->getClient()->close();
     }
+
+    private function tellThem($something)
+    {
+        $this->send($this->getCurrentChannel(), null, $something);
+    }
+
 }
 


### PR DESCRIPTION
This change adds a `composer install` run to the selfupdate command to allow new libraries to be included in new commands.