### PR TITLE
Split Selfupdate and Restart

### DIFF
--- a/bot.php
+++ b/bot.php
@@ -3,6 +3,7 @@
 require 'vendor/autoload.php';
 use PhpSlackBot\Bot;
 use W3C\Help;
+use W3C\Restart;
 use W3C\SelfUpdate;
 use W3C\Schedule;
 use W3C\WhatTheCommit;
@@ -15,6 +16,7 @@ $bot->setToken(getenv('SLACK_TOKEN'));
  * This is where the magic happens
  */
 $bot->loadCommand(new Help());
+$bot->loadCommand(new Restart());
 $bot->loadCommand(new Schedule());
 $bot->loadCommand(new SelfUpdate());
 $bot->loadCommand(new WhatTheCommit());

--- a/src/WecampBot/Restart.php
+++ b/src/WecampBot/Restart.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace W3C;
+
+use PhpSlackBot\Command\BaseCommand;
+
+class Restart extends BaseCommand
+{
+
+    protected function configure()
+    {
+        $this->setName('!restart');
+    }
+
+    protected function execute($message, $context)
+    {
+
+        /**
+         * Close the client and end the React loop
+         * This will cause the program to end, and supervisorctl to restart it
+         */
+        sleep(1);
+        $this->getClient()->close();
+    }
+
+}
+

--- a/src/WecampBot/SelfUpdate.php
+++ b/src/WecampBot/SelfUpdate.php
@@ -21,14 +21,7 @@ class SelfUpdate extends BaseCommand
         $this->tellThem('Updating my dependencies');
         $this->tellThem('```' . shell_exec($this->updateDependenciesCommand) . '```');
 
-        $this->tellThem('Restarting in 5...');
-
-        /**
-         * Close the client and end the React loop
-         * This will cause the program to end, and supervisorctl to restart it
-         */
-        sleep(5);
-        $this->getClient()->close();
+        $this->tellThem('!restart');
     }
 
     private function tellThem($something)


### PR DESCRIPTION
The Selfupdate command did not output it's messages because the client exists before the `send` is executed asynchronously.

By splitting this, the Selfupdate command the output should have the time to arrive before a restart is triggered. I'm sneakily trying to trigger the restart automatically by sending `!restart`.
*Bwahahahaha*